### PR TITLE
Generate custom modal content on page load

### DIFF
--- a/themes/bento/public/scripts/dev/sourceChecks.js
+++ b/themes/bento/public/scripts/dev/sourceChecks.js
@@ -12,6 +12,8 @@ $(function() {
      * - The total for a group of sources has the class `js-sourceTotalCount`
      * - The checkbox that can check all or none of the related sources has a class of `js-sourceTotalCheck
      * - There is also an HTML layout assumption
+     * - There is a base 'template' in the DOM with an id of `sourceTemplate` and where the generated elements
+     *   are to be inserted is inside an element with the id `sourceTemplateContainer`
      *
      * Layout:
      * `.js-source` contains all event source checkboxes and the total counts and total check elements
@@ -23,14 +25,73 @@ $(function() {
             sourceChecks = {
                 /* Called when a new instance of `SourceChecks` is instantiated */
                 init: function() {
-                    var sourceHolders = $('.js-source');
+                    this.createCheckHtml();
+                    this.populateSourceArray();
+                    this.bindEvents();
+                    this.sourceColumnSetup();
+                },
+                /*
+                 * Creates the source checkbox templates based on a 'template' in the dom. Simply grabs the
+                 * template html, replaces a couple of handlebar-like strings, and inserts a new dom node.
+                 *
+                 * Note: we could have used a proper FE template engine here but I can't see the benefit yet
+                 * of adding that overhead for this single use
+                 */
+                createCheckHtml: function() {
+                    /* Creates a camelCase version of the string that is passed through */
+                    function formatName(name) {
+                        var returnText = "";
+                        for (var i = 0, len = name.length; i < len; i++) {
+                            var c = name[i];
+                            if (c === ' ') {
+                                // Capitalise the next character and ignore the space
+                                i++;
+                                try {
+                                    c = name[i].toUpperCase();
+                                } catch(e) {
+                                    continue;
+                                }
+                            }
+                            returnText += c;
+                        }
+                        return returnText;
+                    }
+
+                    var $container = $('#sourceTemplateContainer'),
+                        $template = $('#sourceTemplate'),
+                        templateHtml = $template.html();
+
+                    window.CAL.eventSources.forEach(function(cal) {
+                        // Make sure we have something to work with here
+                        if (!cal.name) {
+                            return;
+                        }
+                        var sourceHtml = templateHtml.replace(/{{name}}/g, cal.name)
+                            .replace(/{{formattedName}}/g, formatName(cal.name));
+                        $container.append(sourceHtml);
+                    });
+
+                    $template.remove();
+                },
+                /*
+                 * We keep an array of all the checkboxes and their associated metadata
+                 * This function scours the dom for these checkboxes and populates the
+                 * array
+                 */
+                populateSourceArray: function() {
+                    var me = this,
+                        sourceHolders = $('.js-source');
 
                     // For each group of sources, create a collection of related elements
                     sourceHolders.each(function(index, source) {
                         var $source = $(source),
-                            $sourceTotalCheck = $source.find('.js-sourceTotalCheck'),
-                            $sourceTotalCount = $source.find('.js-sourceTotalCount'),
-                            $sourceChecks = $source.find('.js-sourceCheck');
+                        $sourceTotalCheck,
+                        $sourceTotalCount,
+                        $sourceChecks;
+
+                        $sourceTotalCheck = $source.find('.js-sourceTotalCheck');
+                        $sourceTotalCount = $source.find('.js-sourceTotalCount');
+                        $sourceChecks = $source.find('.js-sourceCheck');
 
                         sources.push({
                             totalCheck: $sourceTotalCheck,
@@ -38,11 +99,10 @@ $(function() {
                             sourceChecks: $sourceChecks
                         });
 
+                        me.updateTotalCheckCount(null, $sourceTotalCount, ['(All', $sourceChecks.length, 'selected)'].join(' '));
+
+
                     });
-
-                    this.bindEvents();
-                    this.sourceColumnSetup();
-
                 },
                 /* Binds any events onto the elements contained within the `sources` array generated
                    in the `init()` function */

--- a/themes/bento/public/scripts/dev/sourceChecks.js
+++ b/themes/bento/public/scripts/dev/sourceChecks.js
@@ -85,9 +85,9 @@ $(function() {
                     // For each group of sources, create a collection of related elements
                     sourceHolders.each(function(index, source) {
                         var $source = $(source),
-                        $sourceTotalCheck,
-                        $sourceTotalCount,
-                        $sourceChecks;
+                            $sourceTotalCheck,
+                            $sourceTotalCount,
+                            $sourceChecks;
 
                         $sourceTotalCheck = $source.find('.js-sourceTotalCheck');
                         $sourceTotalCount = $source.find('.js-sourceTotalCount');

--- a/themes/bento/public/scripts/dist/script.js
+++ b/themes/bento/public/scripts/dist/script.js
@@ -496,6 +496,8 @@ $(function() {
      * - The total for a group of sources has the class `js-sourceTotalCount`
      * - The checkbox that can check all or none of the related sources has a class of `js-sourceTotalCheck
      * - There is also an HTML layout assumption
+     * - There is a base 'template' in the DOM with an id of `sourceTemplate` and where the generated elements
+     *   are to be inserted is inside an element with the id `sourceTemplateContainer`
      *
      * Layout:
      * `.js-source` contains all event source checkboxes and the total counts and total check elements
@@ -507,14 +509,73 @@ $(function() {
             sourceChecks = {
                 /* Called when a new instance of `SourceChecks` is instantiated */
                 init: function() {
-                    var sourceHolders = $('.js-source');
+                    this.createCheckHtml();
+                    this.populateSourceArray();
+                    this.bindEvents();
+                    this.sourceColumnSetup();
+                },
+                /*
+                 * Creates the source checkbox templates based on a 'template' in the dom. Simply grabs the
+                 * template html, replaces a couple of handlebar-like strings, and inserts a new dom node.
+                 *
+                 * Note: we could have used a proper FE template engine here but I can't see the benefit yet
+                 * of adding that overhead for this single use
+                 */
+                createCheckHtml: function() {
+                    /* Creates a camelCase version of the string that is passed through */
+                    function formatName(name) {
+                        var returnText = "";
+                        for (var i = 0, len = name.length; i < len; i++) {
+                            var c = name[i];
+                            if (c === ' ') {
+                                // Capitalise the next character and ignore the space
+                                i++;
+                                try {
+                                    c = name[i].toUpperCase();
+                                } catch(e) {
+                                    continue;
+                                }
+                            }
+                            returnText += c;
+                        }
+                        return returnText;
+                    }
+
+                    var $container = $('#sourceTemplateContainer'),
+                        $template = $('#sourceTemplate'),
+                        templateHtml = $template.html();
+
+                    window.CAL.eventSources.forEach(function(cal) {
+                        // Make sure we have something to work with here
+                        if (!cal.name) {
+                            return;
+                        }
+                        var sourceHtml = templateHtml.replace(/{{name}}/g, cal.name)
+                            .replace(/{{formattedName}}/g, formatName(cal.name));
+                        $container.append(sourceHtml);
+                    });
+
+                    $template.remove();
+                },
+                /*
+                 * We keep an array of all the checkboxes and their associated metadata
+                 * This function scours the dom for these checkboxes and populates the
+                 * array
+                 */
+                populateSourceArray: function() {
+                    var me = this,
+                        sourceHolders = $('.js-source');
 
                     // For each group of sources, create a collection of related elements
                     sourceHolders.each(function(index, source) {
                         var $source = $(source),
-                            $sourceTotalCheck = $source.find('.js-sourceTotalCheck'),
-                            $sourceTotalCount = $source.find('.js-sourceTotalCount'),
-                            $sourceChecks = $source.find('.js-sourceCheck');
+                        $sourceTotalCheck,
+                        $sourceTotalCount,
+                        $sourceChecks;
+
+                        $sourceTotalCheck = $source.find('.js-sourceTotalCheck');
+                        $sourceTotalCount = $source.find('.js-sourceTotalCount');
+                        $sourceChecks = $source.find('.js-sourceCheck');
 
                         sources.push({
                             totalCheck: $sourceTotalCheck,
@@ -522,11 +583,10 @@ $(function() {
                             sourceChecks: $sourceChecks
                         });
 
+                        me.updateTotalCheckCount(null, $sourceTotalCount, ['(All', $sourceChecks.length, 'selected)'].join(' '));
+
+
                     });
-
-                    this.bindEvents();
-                    this.sourceColumnSetup();
-
                 },
                 /* Binds any events onto the elements contained within the `sources` array generated
                    in the `init()` function */

--- a/themes/bento/public/stylesheets/_sources.scss
+++ b/themes/bento/public/stylesheets/_sources.scss
@@ -136,7 +136,7 @@ $negDimension: $dimension * -1;
     z-index: 1;
 
     &-circle {
-        top: 13px;
+        top: $dimension - 2;
     }
 }
 

--- a/themes/bento/public/stylesheets/styles.css
+++ b/themes/bento/public/stylesheets/styles.css
@@ -1032,7 +1032,7 @@ p {
   z-index: 1;
 }
 .sourcesCheckDisplay-circle {
-  top: 13px;
+  top: 36px;
 }
 
 .sourcesCheck + .sourcesCheckDisplay {

--- a/themes/bento/views/customise.erb
+++ b/themes/bento/views/customise.erb
@@ -5,90 +5,24 @@
       <p id="customise-desc">Select which event sources you want to include in the listing</p>
     </header>
     <div class="modalBody">
-      
+
 
       <fieldset class="sources js-source">
-        <legend class="sourcesTitle" aria-live="polite">Design sources <span class="sourcesSelected js-sourceTotalCount">(7 of 9 selected)</span></legend>
-        <input type="checkbox" id="allDesignSources" class="u-hidden sourcesCheck js-sourceTotalCheck">
+        <legend class="sourcesTitle" aria-live="polite">Sources <span class="sourcesSelected js-sourceTotalCount">(7 of 9 selected)</span></legend>
+        <input type="checkbox" id="allSources" class="u-hidden sourcesCheck js-sourceTotalCheck" checked="checked">
         <span class="sourcesCheckDisplay sourcesCheckDisplay-circle"></span>
-        <label class="sourcesLabel" for="allDesignSources"><strong>All design sources</strong></label>
-        <div class="pure-g sourcesGrid">
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="cssWellington" class="u-hidden sourcesCheck js-sourceCheck">
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="cssWellington">CSS Wellington</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="designPro" class="u-hidden sourcesCheck js-sourceCheck" checked>
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="designPro">Design Pro</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="uxWellington" class="u-hidden sourcesCheck js-sourceCheck" checked>
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="uxWellington">UX Wellington</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="creativeToolsMeetup" class="u-hidden sourcesCheck js-sourceCheck" checked>
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="creativeToolsMeetup">Creative Tools Meetup</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="designThinking" class="u-hidden sourcesCheck js-sourceCheck" checked>
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="designThinking">Design &amp; Thinking</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="typeMeet" class="u-hidden sourcesCheck js-sourceCheck" checked>
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="typeMeet">TypeMeet</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="designCinema" class="u-hidden sourcesCheck js-sourceCheck" checked>
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="designCinema">Design Cinema</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="photographyMeetup" class="u-hidden sourcesCheck js-sourceCheck" checked>
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="photographyMeetup">Photography Meetup</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="webstock" class="u-hidden sourcesCheck js-sourceCheck" checked>
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="webstock">Webstock</label>
-          </div>
+        <label class="sourcesLabel" for="allSources"><strong>All sources</strong></label>
+        <div class="pure-g sourcesGrid" id="sourceTemplateContainer">
+            <div id="sourceTemplate">
+                <div class="pure-u-1-3 sourcesGridCell">
+                    <input type="checkbox" id="{{formattedName}}" class="u-hidden sourcesCheck js-sourceCheck" checked="checked">
+                    <span class="sourcesCheckDisplay"></span>
+                    <label class="sourcesLabel" for="{{formattedName}}">{{name}}</label>
+                </div>
+            </div>
         </div>
       </fieldset>
 
-      <fieldset class="sources js-source">
-        <legend class="sourcesTitle" aria-live="polite">Dev sources <span class="sourcesSelected js-sourceTotalCount">(2 of 4 selected)</span></legend>
-        <input type="checkbox" id="allDevSources" class="u-hidden sourcesCheck js-sourceTotalCheck">
-        <span class="sourcesCheckDisplay sourcesCheckDisplay-circle"></span>
-        <label class="sourcesLabel" for="allDevSources"><strong>All technology sources</strong></label>
-        <div class="pure-g sourcesGrid">
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="agileWellington" class="u-hidden sourcesCheck js-sourceCheck">
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="agileWellington">Agile Wellington</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="machintoshSociety" class="u-hidden sourcesCheck js-sourceCheck" checked>
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="machintoshSociety">Macintosh Society</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="sharepointUsergroup" class="u-hidden sourcesCheck js-sourceCheck">
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="sharepointUsergroup">Sharepoint Usergroup</label>
-          </div>
-          <div class="pure-u-1-3 sourcesGridCell">
-            <input type="checkbox" id="netUsergroup" class="u-hidden sourcesCheck js-sourceCheck" checked>
-            <span class="sourcesCheckDisplay"></span>
-            <label class="sourcesLabel" for="netUsergroup">.NET Usergroup</label>
-          </div>
-        </div>
-      </fieldset>
     </div>
     <footer class="modalFooter">
       <div class="modalFooter--buttonHolder">


### PR DESCRIPTION
I had the thought of bringing in a tempting library but it seems overkill. Generating the modal's HTML goes a little something like:
- The page loads with little interactive modal html
- We iterate through the event sources and pull out each of the names
- For each of the names we give it some metadata (camelCase of the name) to use later on when I make the customise checks actually change the main content
- There's a 'template' in the modal which is just a div with some handlebar-esque tags inside it which get replaced with the event name data. Also update the total # checked.
- We delete the template
- These sources are added to the DOM and event listeners are added to them in the same manner that they were previously

Also updated a check that was out of place.
