### PR TITLE
A few more design tweaks and linting warning fixes

### DIFF
--- a/themes/bento/public/scripts/dev/graphs.js
+++ b/themes/bento/public/scripts/dev/graphs.js
@@ -2,13 +2,7 @@ $(function() {
     // Graph container and dimensions
     var $containerEl = $('.js-graph'),
         containerElWidth = $containerEl.width(),
-        containerElHeight = $containerEl.height(),
-        lazyGraphRemoval = _.debounce(destroyGraphs, 10),
-        lazyGraphRecalculation = _.debounce(showResizedGraphs, 150);
-
-    // Bind window resize event to destroy andrecalculate graphs on browser window size change
-    $(window).on('resize', lazyGraphRemoval);
-    $(window).on('resize', lazyGraphRecalculation);
+        containerElHeight = $containerEl.height();
 
     // Right. Let's do this.
     showGraphs();
@@ -81,7 +75,7 @@ $(function() {
             dateLabel: firstItem.startDate.format('MMM'),
             month: firstItem.startDate.format('MM'),
             year: firstItem.startDate.format('YYYY')
-        }
+        };
     }
 
     /* Build the expeced data structure for a day of events (expected use in _.map) */
@@ -105,7 +99,7 @@ $(function() {
                 if (!currentDay) {
                     continue;
                 }
-                if (currentDay.dateKey == dateKey) {
+                if (currentDay.dateKey === dateKey) {
                     return currentDay;
                 }
             }
@@ -266,7 +260,7 @@ $(function() {
                 .range([0, containerElHeight - margin - 15]),
             xAxis = d3.svg.axis()
                 .scale(x)
-                .orient("bottom"),
+                .orient('bottom'),
             yAxis = d3.svg.axis()
                 .orient('left'),
             xAxisTickClass = monthData.showAxisLines ? 'axis' : 'axis axis-hideTicks',
@@ -282,50 +276,50 @@ $(function() {
             .append('g');
 
         // Create the individual bars for the graph
-        svg.selectAll("rect")
+        svg.selectAll('rect')
             .data(monthData.data)
-            .enter().append("rect")
-            .style("fill", "white")
-            .attr("x", function(d) { return x(returnDate(d)); })
-            .attr("width", x.rangeBand())
+            .enter().append('rect')
+            .style('fill', 'white')
+            .attr('x', function(d) { return x(returnDate(d)); })
+            .attr('width', x.rangeBand())
             // Note: below the -1 creates a 1px gap between the axis the bar
-            .attr("y", function(d) {
+            .attr('y', function(d) {
                 var count = d.count > maxY ? maxY : d.count;
                 return containerElHeight - lineHeight - 1 - y(count);
             })
-            .attr("height", function(d) { return y(d.count) || 0; })
+            .attr('height', function(d) { return y(d.count) || 0; })
             // monthData.width / monthData.count / 2 => offset the axis by half a bar to get the axis dashes in the right place
-            .attr("transform", "translate(" + barOffset + ", 0)")
+            .attr('transform', 'translate(' + barOffset + ', 0)')
             .attr('class', 'graphBar');
 
         // Create the x axis
         // containerElHeight - lineHeight => makes room for the label the label sits
-        svg.append("g")
-            .attr("class", xAxisTickClass)
-            .attr("transform", "translate(0," + (containerElHeight - lineHeight) + ")")
+        svg.append('g')
+            .attr('class', xAxisTickClass)
+            .attr('transform', 'translate(0,' + (containerElHeight - lineHeight) + ')')
             .call(xAxis);
 
         // Start axis line divider
-        svg.append("rect")
-            .attr("class", 'graphDivider')
-            .attr("height", 20)
-            .attr("width", 1)
-            .attr("transform", "translate(0," + (containerElHeight - lineHeight) + ")");
+        svg.append('rect')
+            .attr('class', 'graphDivider')
+            .attr('height', 20)
+            .attr('width', 1)
+            .attr('transform', 'translate(0,' + (containerElHeight - lineHeight) + ')');
 
         if (monthData.index + 1 === monthData.totalMonths) {
             // End axis line divider
-            svg.append("rect")
-                .attr("class", 'graphDivider')
-                .attr("height", 20)
-                .attr("width", 1)
-                .attr("transform", "translate(" + (monthData.width - 1) + "," + (containerElHeight - lineHeight) + ")");
+            svg.append('rect')
+                .attr('class', 'graphDivider')
+                .attr('height', 20)
+                .attr('width', 1)
+                .attr('transform', 'translate(' + (monthData.width - 1) + ',' + (containerElHeight - lineHeight) + ')');
         }
 
         // Append the text to the axis
-        svg.append("text")
-            .attr("class", "axisLabel")
-            .attr("transform", "translate(" + (monthData.width / 2) + " ," + containerElHeight +")")
-            .style("text-anchor", "middle")
+        svg.append('text')
+            .attr('class', 'axisLabel')
+            .attr('transform', 'translate(' + (monthData.width / 2) + ' ,' + containerElHeight +')')
+            .style('text-anchor', 'middle')
             .text(monthData.label);
 
     }
@@ -333,7 +327,7 @@ $(function() {
     /* Actually utlise all the functions above and create the graphs */
     function showGraphs() {
       // Sort and group all our data into to the correct format
-      var sortedDates = _.chain(CAL.eventSources)
+      var sortedDates = _.chain(window.CAL.eventSources)
           .reduce(getSourcesEventData, [])
           .map(createStartDate)
           .sortBy(function(d) {
@@ -343,11 +337,10 @@ $(function() {
                   .minutes(0)
                   .seconds(0)
                   .milliseconds(0)
-                  .toDate()
+                  .toDate();
               })
           .groupBy(groupByMonth)
-          .map(buildMonthData).value(),
-          numberOfMonths = sortedDates.length;
+          .map(buildMonthData).value();
 
       var graphData = buildMultigraphData(sortedDates);
 
@@ -357,19 +350,5 @@ $(function() {
           month.totalMonths = graphData.length;
           displayMonth(month);
       });
-    }
-
-    /* Destroy the current graphs */
-    function destroyGraphs() {
-      $containerEl.html('');
-    }
-
-    /* Rebuilds graphs and recalculate the appropriate graph dimensions */
-    function showResizedGraphs() {
-      // Recaulate the closure variables for the new element sizes
-      containerElWidth = $containerEl.width(),
-      containerElHeight = $containerEl.height();
-
-      showGraphs();
     }
 });

--- a/themes/bento/public/scripts/dist/script.js
+++ b/themes/bento/public/scripts/dist/script.js
@@ -2,13 +2,7 @@ $(function() {
     // Graph container and dimensions
     var $containerEl = $('.js-graph'),
         containerElWidth = $containerEl.width(),
-        containerElHeight = $containerEl.height(),
-        lazyGraphRemoval = _.debounce(destroyGraphs, 10),
-        lazyGraphRecalculation = _.debounce(showResizedGraphs, 150);
-
-    // Bind window resize event to destroy andrecalculate graphs on browser window size change
-    $(window).on('resize', lazyGraphRemoval);
-    $(window).on('resize', lazyGraphRecalculation);
+        containerElHeight = $containerEl.height();
 
     // Right. Let's do this.
     showGraphs();
@@ -81,7 +75,7 @@ $(function() {
             dateLabel: firstItem.startDate.format('MMM'),
             month: firstItem.startDate.format('MM'),
             year: firstItem.startDate.format('YYYY')
-        }
+        };
     }
 
     /* Build the expeced data structure for a day of events (expected use in _.map) */
@@ -105,7 +99,7 @@ $(function() {
                 if (!currentDay) {
                     continue;
                 }
-                if (currentDay.dateKey == dateKey) {
+                if (currentDay.dateKey === dateKey) {
                     return currentDay;
                 }
             }
@@ -266,7 +260,7 @@ $(function() {
                 .range([0, containerElHeight - margin - 15]),
             xAxis = d3.svg.axis()
                 .scale(x)
-                .orient("bottom"),
+                .orient('bottom'),
             yAxis = d3.svg.axis()
                 .orient('left'),
             xAxisTickClass = monthData.showAxisLines ? 'axis' : 'axis axis-hideTicks',
@@ -282,50 +276,50 @@ $(function() {
             .append('g');
 
         // Create the individual bars for the graph
-        svg.selectAll("rect")
+        svg.selectAll('rect')
             .data(monthData.data)
-            .enter().append("rect")
-            .style("fill", "white")
-            .attr("x", function(d) { return x(returnDate(d)); })
-            .attr("width", x.rangeBand())
+            .enter().append('rect')
+            .style('fill', 'white')
+            .attr('x', function(d) { return x(returnDate(d)); })
+            .attr('width', x.rangeBand())
             // Note: below the -1 creates a 1px gap between the axis the bar
-            .attr("y", function(d) {
+            .attr('y', function(d) {
                 var count = d.count > maxY ? maxY : d.count;
                 return containerElHeight - lineHeight - 1 - y(count);
             })
-            .attr("height", function(d) { return y(d.count) || 0; })
+            .attr('height', function(d) { return y(d.count) || 0; })
             // monthData.width / monthData.count / 2 => offset the axis by half a bar to get the axis dashes in the right place
-            .attr("transform", "translate(" + barOffset + ", 0)")
+            .attr('transform', 'translate(' + barOffset + ', 0)')
             .attr('class', 'graphBar');
 
         // Create the x axis
         // containerElHeight - lineHeight => makes room for the label the label sits
-        svg.append("g")
-            .attr("class", xAxisTickClass)
-            .attr("transform", "translate(0," + (containerElHeight - lineHeight) + ")")
+        svg.append('g')
+            .attr('class', xAxisTickClass)
+            .attr('transform', 'translate(0,' + (containerElHeight - lineHeight) + ')')
             .call(xAxis);
 
         // Start axis line divider
-        svg.append("rect")
-            .attr("class", 'graphDivider')
-            .attr("height", 20)
-            .attr("width", 1)
-            .attr("transform", "translate(0," + (containerElHeight - lineHeight) + ")");
+        svg.append('rect')
+            .attr('class', 'graphDivider')
+            .attr('height', 20)
+            .attr('width', 1)
+            .attr('transform', 'translate(0,' + (containerElHeight - lineHeight) + ')');
 
         if (monthData.index + 1 === monthData.totalMonths) {
             // End axis line divider
-            svg.append("rect")
-                .attr("class", 'graphDivider')
-                .attr("height", 20)
-                .attr("width", 1)
-                .attr("transform", "translate(" + (monthData.width - 1) + "," + (containerElHeight - lineHeight) + ")");
+            svg.append('rect')
+                .attr('class', 'graphDivider')
+                .attr('height', 20)
+                .attr('width', 1)
+                .attr('transform', 'translate(' + (monthData.width - 1) + ',' + (containerElHeight - lineHeight) + ')');
         }
 
         // Append the text to the axis
-        svg.append("text")
-            .attr("class", "axisLabel")
-            .attr("transform", "translate(" + (monthData.width / 2) + " ," + containerElHeight +")")
-            .style("text-anchor", "middle")
+        svg.append('text')
+            .attr('class', 'axisLabel')
+            .attr('transform', 'translate(' + (monthData.width / 2) + ' ,' + containerElHeight +')')
+            .style('text-anchor', 'middle')
             .text(monthData.label);
 
     }
@@ -333,7 +327,7 @@ $(function() {
     /* Actually utlise all the functions above and create the graphs */
     function showGraphs() {
       // Sort and group all our data into to the correct format
-      var sortedDates = _.chain(CAL.eventSources)
+      var sortedDates = _.chain(window.CAL.eventSources)
           .reduce(getSourcesEventData, [])
           .map(createStartDate)
           .sortBy(function(d) {
@@ -343,11 +337,10 @@ $(function() {
                   .minutes(0)
                   .seconds(0)
                   .milliseconds(0)
-                  .toDate()
+                  .toDate();
               })
           .groupBy(groupByMonth)
-          .map(buildMonthData).value(),
-          numberOfMonths = sortedDates.length;
+          .map(buildMonthData).value();
 
       var graphData = buildMultigraphData(sortedDates);
 
@@ -357,20 +350,6 @@ $(function() {
           month.totalMonths = graphData.length;
           displayMonth(month);
       });
-    }
-
-    /* Destroy the current graphs */
-    function destroyGraphs() {
-      $containerEl.html('');
-    }
-
-    /* Rebuilds graphs and recalculate the appropriate graph dimensions */
-    function showResizedGraphs() {
-      // Recaulate the closure variables for the new element sizes
-      containerElWidth = $containerEl.width(),
-      containerElHeight = $containerEl.height();
-
-      showGraphs();
     }
 });
 ;$(function() {

--- a/themes/bento/public/stylesheets/_base.scss
+++ b/themes/bento/public/stylesheets/_base.scss
@@ -14,6 +14,14 @@ body {
     -webkit-font-smoothing: antialiased;
 }
 
+/* Adds a slight border on the sides of the main content for smaller devices */
+@media (max-width: $maxWidth) {
+    body {
+        border-left: $bodyBorderWidth solid $primary;
+        border-right: $bodyBorderWidth solid $primary;
+    }
+}
+
 a {
     color: $primary;
     text-decoration: none;

--- a/themes/bento/public/stylesheets/_graphs.scss
+++ b/themes/bento/public/stylesheets/_graphs.scss
@@ -2,6 +2,7 @@
  * CONTENTS
  *
  * Holder................Any container specific styles we need
+ * Scroller..............The element that makes the graph holder x-scroll on small screens
  * Axis..................Details to do with the resulting SVG axis
  */
 
@@ -10,12 +11,21 @@
 \*------------------------------------*/
 .graphHolder {
     height: $graphHeight;
+    width: $maxWidth;
 }
 
 @media (max-width: $maxWidth) {
   .graphHolder {
     margin-top: $alphaTextSize;
   }
+}
+
+/*------------------------------------*\
+    #SCROLLER
+\*------------------------------------*/
+.graphScroller {
+    overflow: hidden;
+    overflow-x: scroll;
 }
 
 /*------------------------------------*\

--- a/themes/bento/public/stylesheets/_layout.scss
+++ b/themes/bento/public/stylesheets/_layout.scss
@@ -12,7 +12,7 @@
 
 
 @media (max-width: $maxWidth) {
-  .l-mainContent {
-    margin: 0 10px;
-  }
+    .l-mainContent {
+      margin: 0 10px;
+    }
 }

--- a/themes/bento/public/stylesheets/_variables.scss
+++ b/themes/bento/public/stylesheets/_variables.scss
@@ -90,7 +90,6 @@ $groupPercentMobile: 70%;
 $titlePercentMobile: 50%;
 $locationPercentMobile: 30%;
 
-
 /*------------------------------------*\
     #SOURCES GRID
 \*------------------------------------*/
@@ -116,3 +115,4 @@ $graphHeight: 60px;
 /*------------------------------------*\
     #MOBILE
 \*------------------------------------*/
+$bodyBorderWidth: 3px;

--- a/themes/bento/public/stylesheets/styles.css
+++ b/themes/bento/public/stylesheets/styles.css
@@ -1083,6 +1083,7 @@ p {
  * CONTENTS
  *
  * Holder................Any container specific styles we need
+ * Scroller..............The element that makes the graph holder x-scroll on small screens
  * Axis..................Details to do with the resulting SVG axis
  */
 /*------------------------------------*\
@@ -1090,6 +1091,7 @@ p {
 \*------------------------------------*/
 .graphHolder {
   height: 60px;
+  width: 940px;
 }
 
 @media (max-width: 940px) {
@@ -1097,6 +1099,14 @@ p {
     margin-top: 32px;
   }
 }
+/*------------------------------------*\
+    #SCROLLER
+\*------------------------------------*/
+.graphScroller {
+  overflow: hidden;
+  overflow-x: scroll;
+}
+
 /*------------------------------------*\
     #AXIS
 

--- a/themes/bento/public/stylesheets/styles.css
+++ b/themes/bento/public/stylesheets/styles.css
@@ -260,6 +260,13 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* Adds a slight border on the sides of the main content for smaller devices */
+@media (max-width: 940px) {
+  body {
+    border-left: 3px solid #e52a08;
+    border-right: 3px solid #e52a08;
+  }
+}
 a {
   color: #e52a08;
   text-decoration: none;

--- a/themes/bento/test.html
+++ b/themes/bento/test.html
@@ -11,7 +11,7 @@
 
 	<header class="header" role="banner">
 		<div class="l-mainContent">
-			<h1 class="headerTitle" id="calender-label">Design Event Calendar</h1>
+			<h1 class="headerTitle" id="calender-label">Event Calendar</h1>
 
 			<p class="headerActions">Feel free to <button class="headerAction js-navLink" aria-controls="section-customise">customise this listing</button> and <button class="headerAction js-navLink" aria-controls="section-export">export to your calendar</button></p>
 

--- a/themes/bento/test.html
+++ b/themes/bento/test.html
@@ -15,7 +15,9 @@
 
 			<p class="headerActions">Feel free to <button class="headerAction js-navLink" aria-controls="section-customise">customise this listing</button> and <button class="headerAction js-navLink" aria-controls="section-export">export to your calendar</button></p>
 
-			<div class="graphHolder js-graph"></div>
+			<div class="graphScroller">
+				<div class="graphHolder js-graph"></div>
+			</div>
 		</div>
 	</header>
 

--- a/themes/bento/views/header.erb
+++ b/themes/bento/views/header.erb
@@ -6,6 +6,8 @@
       <p>Feel free to <button class="headerAction js-navLink" aria-controls="section-customise">customise this listing</button> and <button class="headerAction js-navLink" aria-controls="section-export">export to your calendar</button></p>
     </div>
 
-    <div class="graphHolder js-graph"></div>
+    <div class="graphScroller">
+        <div class="graphHolder js-graph"></div>
+    </div>
   </div>
 </header>

--- a/themes/bento/views/header.erb
+++ b/themes/bento/views/header.erb
@@ -1,6 +1,6 @@
 <header class="header" role="banner">
   <div class="l-mainContent">
-    <h1 class="headerTitle" id="calender-label">Design Event Calendar</h1>
+    <h1 class="headerTitle" id="calender-label">Event Calendar</h1>
 
     <div class="headerActions">
       <p>Feel free to <button class="headerAction js-navLink" aria-controls="section-customise">customise this listing</button> and <button class="headerAction js-navLink" aria-controls="section-export">export to your calendar</button></p>


### PR DESCRIPTION
### Design changes
- There's a small left and right border on the main content when the screen's smaller than the max width (i.e non-desktop or tablet)
- Changed the title to `Event calendar` instead of `Design event calendar` until there's an actual separation between dev and design calendars.
- The graph now doesn't recalculate itself on the window resize but instead is always a set size with horizontal scrolling
### Linting

Just a few tweaks to stop JSHint complaining
